### PR TITLE
Fix buffer cleanup for Selected Towers

### DIFF
--- a/src/pages/viewer/StandaloneViewerPage.tsx
+++ b/src/pages/viewer/StandaloneViewerPage.tsx
@@ -396,6 +396,17 @@ const StandaloneViewerPage: React.FC = () => {
                     });
                 }
 
+                // Also reset buffer visibility for selected towers
+                setBufferVisibility(prevBuffers => {
+                    const updated: Record<string, boolean> = { ...prevBuffers };
+                    Object.keys(updated).forEach(id => {
+                        if (id.startsWith('buffer_-1_')) {
+                            updated[id] = false;
+                        }
+                    });
+                    return updated;
+                });
+
                 return newSet;
             }
         });
@@ -1059,11 +1070,14 @@ const StandaloneViewerPage: React.FC = () => {
                 }
 
                 // Register with zoom visibility manager
+                // Selected towers should ignore zoom restrictions
+                const customMinZoom = layerInfo.id === -1 ? 0 : undefined;
                 zoomVisibilityManager.registerLayer(
                     layerInfo.id,
                     layerInfo.name,
                     isTowerLayer,
-                    shouldBeVisible // FIX 3: Pass actual visibility state
+                    shouldBeVisible, // FIX 3: Pass actual visibility state
+                    customMinZoom
                 );
 
                 // Generate frontend buffer layers for antenna towers


### PR DESCRIPTION
## Summary
- keep Selected Towers buffers hidden when there are no selections
- ignore zoom restrictions when registering Selected Towers layer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ded22a77883328d9d27e971b1f809