### PR TITLE
Fix buffer toggle for Selected Towers

### DIFF
--- a/src/pages/viewer/StandaloneViewerPage.tsx
+++ b/src/pages/viewer/StandaloneViewerPage.tsx
@@ -230,6 +230,11 @@ const StandaloneViewerPage: React.FC = () => {
                     // ✅ When tower layer is turned OFF, force hide and disable all buffers
                     frontendBufferManager.toggleParentLayerBuffers(layerId, false, mapRef.current);
 
+                    if (layerId === -1) {
+                        // Immediately hide selected towers layer and its buffers
+                        selectedTowersManager.toggleSelectedLayerVisibility(false);
+                    }
+
                     // Also update buffer visibility state to reflect that buffers are off
                     setBufferVisibility(prevBufferState => {
                         const newBufferState = { ...prevBufferState };
@@ -395,6 +400,17 @@ const StandaloneViewerPage: React.FC = () => {
                         }
                     });
                 }
+
+                // Also reset buffer visibility for selected towers
+                setBufferVisibility(prevBuffers => {
+                    const updated: Record<string, boolean> = { ...prevBuffers };
+                    Object.keys(updated).forEach(id => {
+                        if (id.startsWith('buffer_-1_')) {
+                            updated[id] = false;
+                        }
+                    });
+                    return updated;
+                });
 
                 return newSet;
             }
@@ -1059,11 +1075,14 @@ const StandaloneViewerPage: React.FC = () => {
                 }
 
                 // Register with zoom visibility manager
+                // Selected towers should ignore zoom restrictions
+                const customMinZoom = layerInfo.id === -1 ? 0 : undefined;
                 zoomVisibilityManager.registerLayer(
                     layerInfo.id,
                     layerInfo.name,
                     isTowerLayer,
-                    shouldBeVisible // FIX 3: Pass actual visibility state
+                    shouldBeVisible, // FIX 3: Pass actual visibility state
+                    customMinZoom
                 );
 
                 // Generate frontend buffer layers for antenna towers
@@ -1372,12 +1391,17 @@ const StandaloneViewerPage: React.FC = () => {
                         onSelectedTowersToggle={(isVisible) => {
                             if (isVisible) {
                                 setVisibleLayers(prev => new Set([...prev, -1]));
+                                selectedTowersManager.toggleSelectedLayerVisibility(true);
                             } else {
                                 setVisibleLayers(prev => {
                                     const newSet = new Set(prev);
                                     newSet.delete(-1);
                                     return newSet;
                                 });
+                                selectedTowersManager.toggleSelectedLayerVisibility(false);
+                                if (mapRef.current) {
+                                    frontendBufferManager.toggleParentLayerBuffers(-1, false, mapRef.current);
+                                }
                             }
                         }}
                     />


### PR DESCRIPTION
## Summary
- force-hide selected tower buffers when the layer is unchecked
- immediately hide selected tower buffers via the layer toggle callback

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ded22a77883328d9d27e971b1f809