### PR TITLE
Preserve return path after login

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -29,7 +29,11 @@ const FormContainer = styled(Paper)(({ theme }) => ({
     boxShadow: theme.shadows[3],
 }));
 
-const LoginForm: React.FC = () => {
+interface LoginFormProps {
+    redirectTo: string;
+}
+
+const LoginForm: React.FC<LoginFormProps> = ({ redirectTo }) => {
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
     const [showPassword, setShowPassword] = useState(false);
@@ -42,7 +46,7 @@ const LoginForm: React.FC = () => {
         clearError();
         try {
             await login({ username, password });
-            navigate('/dashboard');
+            navigate(redirectTo, { replace: true });
         } catch (err) {
             console.error('Login failed:', err);
         }

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -2,11 +2,14 @@
 import React from 'react';
 import { Box, Container, Typography, useTheme } from '@mui/material';
 import LoginForm from '../../components/auth/LoginForm.tsx';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation, type Location } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext.tsx';
 
 const LoginPage: React.FC = () => {
     const { isAuthenticated, isLoading } = useAuth();
+    const location = useLocation();
+    const from =
+        (location.state as { from?: Location })?.from?.pathname || '/dashboard';
     const theme = useTheme();
 
     if (isLoading) {
@@ -14,7 +17,7 @@ const LoginPage: React.FC = () => {
     }
 
     if (isAuthenticated) {
-        return <Navigate to="/dashboard" replace />;
+        return <Navigate to={from} replace />;
     }
 
     return (
@@ -46,7 +49,7 @@ const LoginPage: React.FC = () => {
                     </Typography>
                 </Box>
 
-                <LoginForm />
+                <LoginForm redirectTo={from} />
             </Container>
         </Box>
     );


### PR DESCRIPTION
## Summary
- redirect login form to the page requested before authentication
- use router location state to detect previous route

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686493bd4c748332950bc1027aab5fa2