### PR TITLE
Add public access viewer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,7 +84,8 @@ function App() {
                         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
                         <Route path="/reset-password/:token/:uidb64" element={<ResetPasswordPage />} />
 
-                        {/* Standalone Viewer Route - Protected but with special layout */}
+                        {/* Standalone Viewer Routes */}
+                        <Route path="/public/:hash" element={<StandaloneViewerPage />} />
                         <Route path="/viewer/:id" element={<ProtectedRoute component={StandaloneViewerPage} />} />
 
                         {/* Protected Routes with Main Layout */}

--- a/src/components/viewer/StandaloneHeader.tsx
+++ b/src/components/viewer/StandaloneHeader.tsx
@@ -5,6 +5,7 @@ import { styled } from '@mui/material/styles';
 
 interface StandaloneHeaderProps {
     projectName?: string;
+    isPublicAccess?: boolean;
 }
 
 const HeaderContainer = styled(Box)({
@@ -49,11 +50,27 @@ const ContactLink = styled(Link)({
     },
 });
 
-const StandaloneHeader: React.FC<StandaloneHeaderProps> = ({ projectName }) => {
+const StandaloneHeader: React.FC<StandaloneHeaderProps> = ({ projectName, isPublicAccess = false }) => {
     return (
         <HeaderContainer>
             <Title>
                 Wireless2020 WebGisViewer
+                {isPublicAccess && (
+                    <Typography
+                        component="span"
+                        sx={{
+                            fontSize: '12px',
+                            fontWeight: 300,
+                            ml: 1,
+                            opacity: 0.8,
+                            backgroundColor: 'rgba(255,255,255,0.2)',
+                            padding: '2px 6px',
+                            borderRadius: '4px'
+                        }}
+                    >
+                        Public View
+                    </Typography>
+                )}
             </Title>
             <CenterText>
                 {projectName}

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -6,7 +6,8 @@ import {
     ProjectUpdate,
     ProjectStats,
     ProjectConstructor,
-    ProjectCloneRequest
+    ProjectCloneRequest,
+    FeatureCollection
 } from '../types';
 import { PaginatedResponse } from '../types';
 
@@ -74,6 +75,40 @@ export const getStandaloneProject = (hash: string): Promise<ProjectConstructor> 
     return apiGet<ProjectConstructor>(`/standalone/${hash}/`);
 };
 
+export const getPublicProjectConstructor = async (
+    publicToken: string
+): Promise<ProjectConstructor> => {
+    try {
+        return await apiGet<ProjectConstructor>(
+            `/constructor/public/${publicToken}/`,
+            {
+                headers: {
+                    'X-Public-Token': publicToken,
+                    Origin: window.location.origin
+                }
+            }
+        );
+    } catch (error) {
+        throw new Error('Failed to load public project');
+    }
+};
+
+export const getPublicLayerData = async (
+    layerId: number,
+    publicToken: string
+): Promise<FeatureCollection> => {
+    try {
+        return await apiGet<FeatureCollection>(`/data/${layerId}/`, {
+            headers: {
+                'X-Public-Token': publicToken,
+                Origin: window.location.origin
+            }
+        });
+    } catch (error) {
+        throw new Error('Failed to load public layer data');
+    }
+};
+
 // Export default as object with all methods
 const projectService = {
     getProjects,
@@ -84,7 +119,8 @@ const projectService = {
     cloneProject,
     getProjectStats,
     getProjectConstructor,
-    getStandaloneProject
+    getStandaloneProject,
+    getPublicProjectConstructor,
+    getPublicLayerData
 };
-
 export default projectService;


### PR DESCRIPTION
## Summary
- add public viewer route
- handle public vs protected viewer in standalone page
- support public project & layer fetch helpers
- indicate public mode in header

## Testing
- `npm run lint` *(fails: 199 errors)*
- `npm run build` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ed485e6fc8332b90fa2853881f0b7