### PR TITLE
Add dev viewer with basic refactored structure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import NotFoundPage from './pages/NotFoundPage';
 
 // Standalone Viewer
 import StandaloneViewerPage from './pages/viewer/StandaloneViewerPage';
+import StandaloneViewerPageDev from './pages/viewer-dev/StandaloneViewerPageDev';
 
 // Guards
 import ProtectedRoute from './components/auth/ProtectedRoute';
@@ -87,6 +88,8 @@ function App() {
                         {/* Standalone Viewer Routes */}
                         <Route path="/public-viewer/:hash" element={<StandaloneViewerPage />} />
                         <Route path="/viewer/:id" element={<ProtectedRoute component={StandaloneViewerPage} />} />
+                        <Route path="/public-viewer-dev/:hash" element={<StandaloneViewerPageDev />} />
+                        <Route path="/viewer-dev/:id" element={<ProtectedRoute component={StandaloneViewerPageDev} />} />
 
                         {/* Protected Routes with Main Layout */}
                         <Route path="/" element={<ProtectedRoute component={MainLayout} />}>

--- a/src/classes/layers/BaseMapLayer.ts
+++ b/src/classes/layers/BaseMapLayer.ts
@@ -1,0 +1,44 @@
+import * as L from 'leaflet';
+import { IMapLayer, LayerConfig } from '../../interfaces/IMapLayer';
+
+export default abstract class BaseMapLayer implements IMapLayer {
+    public isVisible = false;
+    protected map: L.Map | null = null;
+    protected layer: L.Layer | null = null;
+
+    constructor(
+        public readonly id: number,
+        public readonly name: string,
+        public readonly type: string,
+        public readonly config: LayerConfig
+    ) {}
+
+    async initialize(map: L.Map): Promise<void> {
+        this.map = map;
+    }
+
+    abstract loadData(data: any): Promise<void>;
+
+    show(): void {
+        if (this.map && this.layer && !this.isVisible) {
+            this.map.addLayer(this.layer);
+            this.isVisible = true;
+        }
+    }
+
+    hide(): void {
+        if (this.map && this.layer && this.isVisible) {
+            this.map.removeLayer(this.layer);
+            this.isVisible = false;
+        }
+    }
+
+    destroy(): void {
+        if (this.map && this.layer) {
+            this.map.removeLayer(this.layer);
+        }
+        this.map = null;
+        this.layer = null;
+        this.isVisible = false;
+    }
+}

--- a/src/classes/layers/TowerLayer.ts
+++ b/src/classes/layers/TowerLayer.ts
@@ -1,0 +1,17 @@
+import * as L from 'leaflet';
+import BaseMapLayer from './BaseMapLayer';
+
+export default class TowerLayer extends BaseMapLayer {
+    async loadData(data: any): Promise<void> {
+        if (!this.map) return;
+        const features = data?.features || [];
+        const markers: L.Layer[] = [];
+        for (const feature of features) {
+            if (feature.geometry?.type === 'Point') {
+                const [lng, lat] = feature.geometry.coordinates;
+                markers.push(L.marker([lat, lng]));
+            }
+        }
+        this.layer = L.layerGroup(markers);
+    }
+}

--- a/src/classes/project/ProjectController.ts
+++ b/src/classes/project/ProjectController.ts
@@ -1,0 +1,58 @@
+import * as L from 'leaflet';
+import TowerLayer from '../layers/TowerLayer';
+import BaseMapLayer from '../layers/BaseMapLayer';
+import { IMapLayer, LayerConfig } from '../../interfaces/IMapLayer';
+import projectService from '../../services/projectService';
+import { mapService } from '../../services';
+
+interface ProjectConstructor {
+    project: {
+        default_center_lat: number;
+        default_center_lng: number;
+        default_zoom_level: number;
+    };
+    layer_groups: { layers: LayerConfig[] }[];
+}
+
+export default class ProjectController {
+    private map: L.Map | null = null;
+    private layers: IMapLayer[] = [];
+
+    constructor(private projectId: string | number, private isPublic: boolean) {}
+
+    async loadProject(): Promise<void> {
+        let data: ProjectConstructor;
+        if (this.isPublic) {
+            data = await projectService.getPublicProjectConstructor(String(this.projectId));
+        } else {
+            data = await projectService.getProjectConstructor(Number(this.projectId));
+        }
+        await this.createLayers(data);
+        if (this.map) {
+            this.layers.forEach(layer => layer.initialize(this.map!));
+            await Promise.all(
+                this.layers.map(async layer => {
+                    const layerData = await mapService.getLayerFeatures(layer.id);
+                    await layer.loadData(layerData);
+                })
+            );
+            this.layers.forEach(layer => layer.show());
+        }
+    }
+
+    attachMap(map: L.Map): void {
+        this.map = map;
+    }
+
+    private async createLayers(data: ProjectConstructor): Promise<void> {
+        const layers: IMapLayer[] = [];
+        data.layer_groups.forEach(group => {
+            group.layers.forEach(layerInfo => {
+                if (layerInfo.type === 'tower') {
+                    layers.push(new TowerLayer(layerInfo.id, layerInfo.name, layerInfo.type, layerInfo));
+                }
+            });
+        });
+        this.layers = layers;
+    }
+}

--- a/src/interfaces/IMapLayer.ts
+++ b/src/interfaces/IMapLayer.ts
@@ -1,0 +1,19 @@
+export interface LayerConfig {
+    id: number;
+    name: string;
+    type: string;
+    zIndex?: number;
+}
+
+export interface IMapLayer {
+    readonly id: number;
+    readonly name: string;
+    readonly type: string;
+    isVisible: boolean;
+
+    initialize(map: L.Map): Promise<void>;
+    loadData(data: any): Promise<void>;
+    show(): void;
+    hide(): void;
+    destroy(): void;
+}

--- a/src/pages/viewer-dev/StandaloneViewerPageDev.tsx
+++ b/src/pages/viewer-dev/StandaloneViewerPageDev.tsx
@@ -1,0 +1,37 @@
+// Experimental refactored viewer page
+import React, { useEffect, useRef } from 'react';
+import { useParams, useLocation } from 'react-router-dom';
+import * as L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import StandaloneLoadingScreen from '../../components/viewer/StandaloneLoadingScreen';
+import ProjectController from '../../classes/project/ProjectController';
+
+const StandaloneViewerPageDev: React.FC = () => {
+    const { id, hash } = useParams<{ id?: string; hash?: string }>();
+    const location = useLocation();
+    const mapRef = useRef<HTMLDivElement>(null);
+    const controllerRef = useRef<ProjectController | null>(null);
+
+    const isPublic = location.pathname.startsWith('/public-viewer-dev/');
+    const identifier = isPublic ? hash : id;
+
+    useEffect(() => {
+        if (!identifier || !mapRef.current) return;
+        const map = L.map(mapRef.current).setView([0, 0], 2);
+        const controller = new ProjectController(identifier, isPublic);
+        controller.attachMap(map);
+        controller.loadProject();
+        controllerRef.current = controller;
+        return () => {
+            map.remove();
+        };
+    }, [identifier, isPublic]);
+
+    if (!identifier) {
+        return <StandaloneLoadingScreen progress={0} statusMessage="Loading..." />;
+    }
+
+    return <div ref={mapRef} style={{ height: '100vh', width: '100%' }} />;
+};
+
+export default StandaloneViewerPageDev;


### PR DESCRIPTION
## Summary
- introduce experimental StandaloneViewerPageDev
- scaffold minimal project controller and layer classes
- expose new `/viewer-dev/:id` and `/public-viewer-dev/:hash` routes

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688777242a44833280079da9875d34d3