### PR TITLE
Enable basic map rendering in viewer-dev

### DIFF
--- a/src/classes/layers/GenericLayer.ts
+++ b/src/classes/layers/GenericLayer.ts
@@ -1,0 +1,16 @@
+import * as L from 'leaflet';
+import BaseMapLayer from './BaseMapLayer';
+import { LayerConfig } from '../../interfaces/IMapLayer';
+
+export default class GenericLayer extends BaseMapLayer {
+    constructor(id: number, name: string, type: string, config: LayerConfig) {
+        super(id, name, type, config);
+    }
+
+    async loadData(data: any): Promise<void> {
+        if (!this.map) return;
+        this.layer = L.geoJSON(data, {
+            style: this.config.style as any
+        });
+    }
+}

--- a/src/classes/project/ProjectController.ts
+++ b/src/classes/project/ProjectController.ts
@@ -1,9 +1,19 @@
 import * as L from 'leaflet';
 import TowerLayer from '../layers/TowerLayer';
 import BaseMapLayer from '../layers/BaseMapLayer';
+import GenericLayer from '../layers/GenericLayer';
 import { IMapLayer, LayerConfig } from '../../interfaces/IMapLayer';
 import projectService from '../../services/projectService';
-import { mapService } from '../../services';
+import mapService from '../../services/mapService';
+
+interface BasemapInfo {
+    id: number;
+    name: string;
+    url_template: string;
+    provider: string;
+    options?: Record<string, any>;
+    is_default?: boolean;
+}
 
 interface ProjectConstructor {
     project: {
@@ -12,11 +22,14 @@ interface ProjectConstructor {
         default_zoom_level: number;
     };
     layer_groups: { layers: LayerConfig[] }[];
+    basemaps: BasemapInfo[];
 }
 
 export default class ProjectController {
     private map: L.Map | null = null;
     private layers: IMapLayer[] = [];
+    private basemaps: BasemapInfo[] = [];
+    private activeBasemap: L.TileLayer | null = null;
 
     constructor(private projectId: string | number, private isPublic: boolean) {}
 
@@ -27,16 +40,26 @@ export default class ProjectController {
         } else {
             data = await projectService.getProjectConstructor(Number(this.projectId));
         }
+        this.basemaps = data.basemaps || [];
         await this.createLayers(data);
+
         if (this.map) {
-            this.layers.forEach(layer => layer.initialize(this.map!));
+            // set initial view
+            this.map.setView(
+                [data.project.default_center_lat, data.project.default_center_lng],
+                data.project.default_zoom_level
+            );
+
             await Promise.all(
                 this.layers.map(async layer => {
-                    const layerData = await mapService.getLayerFeatures(layer.id);
+                    await layer.initialize(this.map!);
+                    const layerData = await this.fetchLayerData(layer.id);
                     await layer.loadData(layerData);
+                    layer.show();
                 })
             );
-            this.layers.forEach(layer => layer.show());
+
+            this.setDefaultBasemap();
         }
     }
 
@@ -50,9 +73,61 @@ export default class ProjectController {
             group.layers.forEach(layerInfo => {
                 if (layerInfo.type === 'tower') {
                     layers.push(new TowerLayer(layerInfo.id, layerInfo.name, layerInfo.type, layerInfo));
+                } else {
+                    layers.push(new GenericLayer(layerInfo.id, layerInfo.name, layerInfo.type, layerInfo));
                 }
             });
         });
         this.layers = layers;
+    }
+
+    private async fetchLayerData(layerId: number): Promise<any> {
+        const headers = this.isPublic
+            ? { headers: { 'X-Public-Token': String(this.projectId), Origin: window.location.origin } }
+            : {};
+
+        let chunk = 1;
+        const features: any[] = [];
+        let more = true;
+        while (more) {
+            try {
+                const data = await mapService.getLayerData(layerId, { chunk_id: chunk }, headers);
+                if (data.features && data.features.length) {
+                    features.push(...data.features);
+                    if (data.chunk_info && data.chunk_info.next_chunk) {
+                        chunk = data.chunk_info.next_chunk;
+                    } else {
+                        more = false;
+                    }
+                } else {
+                    more = false;
+                }
+            } catch {
+                more = false;
+            }
+        }
+
+        return { type: 'FeatureCollection', features };
+    }
+
+    private setDefaultBasemap(): void {
+        if (!this.map || this.basemaps.length === 0) return;
+        const defaultBm = this.basemaps.find(b => b.is_default) || this.basemaps[0];
+        if (!defaultBm) return;
+
+        let tileLayer: L.TileLayer;
+
+        if (defaultBm.provider === 'custom' && !defaultBm.url_template) {
+            // white background
+            tileLayer = L.tileLayer('', {
+                minZoom: 0,
+                maxZoom: 22,
+            });
+        } else {
+            tileLayer = L.tileLayer(defaultBm.url_template, defaultBm.options || {});
+        }
+
+        tileLayer.addTo(this.map);
+        this.activeBasemap = tileLayer;
     }
 }

--- a/src/interfaces/IMapLayer.ts
+++ b/src/interfaces/IMapLayer.ts
@@ -3,6 +3,10 @@ export interface LayerConfig {
     name: string;
     type: string;
     zIndex?: number;
+    /** Optional style information used for generic GeoJSON layers */
+    style?: any;
+    /** Enable clustering for point layers */
+    enable_clustering?: boolean;
 }
 
 export interface IMapLayer {


### PR DESCRIPTION
## Summary
- implement GenericLayer for simple GeoJSON layers
- extend `ProjectController` to load basemaps and layers
- add optional style fields to `LayerConfig`
- update viewer-dev page to load project through controller

## Testing
- `npm run lint` *(fails: several lint errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68878379cca483329feebb2ab9b442dd