### PR TITLE
Add layer factory and AntennaTowerLayer

### DIFF
--- a/src/classes/factories/LayerFactory.ts
+++ b/src/classes/factories/LayerFactory.ts
@@ -1,0 +1,17 @@
+import TowerLayer from '../layers/TowerLayer';
+import GenericLayer from '../layers/GenericLayer';
+import AntennaTowerLayer from '../layers/AntennaTowerLayer';
+import { IMapLayer, LayerConfig } from '../../interfaces/IMapLayer';
+
+export default class LayerFactory {
+    static createLayer(config: LayerConfig): IMapLayer {
+        switch (config.type) {
+            case 'tower':
+                return new TowerLayer(config.id, config.name, config.type, config);
+            case 'antenna_tower':
+                return new AntennaTowerLayer(config.id, config.name, config.type, config);
+            default:
+                return new GenericLayer(config.id, config.name, config.type, config);
+        }
+    }
+}

--- a/src/classes/factories/index.ts
+++ b/src/classes/factories/index.ts
@@ -1,0 +1,1 @@
+export { default as LayerFactory } from './LayerFactory';

--- a/src/classes/index.ts
+++ b/src/classes/index.ts
@@ -1,0 +1,3 @@
+export * from './layers';
+export * from './factories';
+export * from './project/ProjectController';

--- a/src/classes/layers/AntennaTowerLayer.ts
+++ b/src/classes/layers/AntennaTowerLayer.ts
@@ -1,0 +1,29 @@
+import * as L from 'leaflet';
+import TowerLayer from './TowerLayer';
+import { LayerConfig } from '../../interfaces/IMapLayer';
+import { towerCompanyColors } from '../../constants/towerConstants';
+
+export default class AntennaTowerLayer extends TowerLayer {
+    constructor(id: number, name: string, type: string, config: LayerConfig) {
+        super(id, name, type, config);
+    }
+
+    async loadData(data: any): Promise<void> {
+        if (!this.map) return;
+        const features = data?.features || [];
+        const markers: L.Layer[] = [];
+        for (const feature of features) {
+            if (feature.geometry?.type === 'Point') {
+                const [lng, lat] = feature.geometry.coordinates;
+                const company = feature.properties?.company || 'Other';
+                const color = towerCompanyColors[company as keyof typeof towerCompanyColors] || towerCompanyColors['Other'];
+                const icon = L.divIcon({
+                    className: 'antenna-tower-icon',
+                    html: `<div style="background-color:${color};width:10px;height:10px;border-radius:50%"></div>`
+                });
+                markers.push(L.marker([lat, lng], { icon }));
+            }
+        }
+        this.layer = L.layerGroup(markers);
+    }
+}

--- a/src/classes/layers/index.ts
+++ b/src/classes/layers/index.ts
@@ -1,0 +1,4 @@
+export { default as BaseMapLayer } from './BaseMapLayer';
+export { default as GenericLayer } from './GenericLayer';
+export { default as TowerLayer } from './TowerLayer';
+export { default as AntennaTowerLayer } from './AntennaTowerLayer';

--- a/src/classes/project/ProjectController.ts
+++ b/src/classes/project/ProjectController.ts
@@ -1,7 +1,5 @@
 import * as L from 'leaflet';
-import TowerLayer from '../layers/TowerLayer';
-import BaseMapLayer from '../layers/BaseMapLayer';
-import GenericLayer from '../layers/GenericLayer';
+import { LayerFactory } from '../factories';
 import { IMapLayer, LayerConfig } from '../../interfaces/IMapLayer';
 import projectService from '../../services/projectService';
 import mapService from '../../services/mapService';
@@ -71,11 +69,7 @@ export default class ProjectController {
         const layers: IMapLayer[] = [];
         data.layer_groups.forEach(group => {
             group.layers.forEach(layerInfo => {
-                if (layerInfo.type === 'tower') {
-                    layers.push(new TowerLayer(layerInfo.id, layerInfo.name, layerInfo.type, layerInfo));
-                } else {
-                    layers.push(new GenericLayer(layerInfo.id, layerInfo.name, layerInfo.type, layerInfo));
-                }
+                layers.push(LayerFactory.createLayer(layerInfo));
             });
         });
         this.layers = layers;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './IMapLayer';


### PR DESCRIPTION
## Summary
- create new `AntennaTowerLayer` class for specialized tower rendering
- introduce `LayerFactory` to construct layers based on type
- export classes through new index files
- refactor `ProjectController` to use the factory when creating layers

## Testing
- `npm run lint` *(fails: 239 problems)*
- `npm run build` *(fails to compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_6887874f8ffc83328a6c9cdfb462d876